### PR TITLE
refactor: use bufwriter for output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,15 +24,20 @@ fn main() {
     let result = format(&opts.url, &stdin.unwrap_or_default());
     match result {
         Ok(v) => {
-            let stdout = io::stdout();
-            let mut writer = io::BufWriter::new(stdout.lock());
-            writer.write_all(v.as_bytes()).unwrap();
+            write_stdout(v.as_bytes()).unwrap();
         }
         Err(e) => {
             eprint!("Error formatting with blackd-client: {}", e);
             std::process::exit(1);
         }
     }
+}
+
+fn write_stdout(buf: &[u8]) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut writer = io::BufWriter::new(stdout.lock());
+    writer.write_all(buf)?;
+    Ok(())
 }
 
 fn read_stdin() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,11 @@ fn main() {
     let stdin = read_stdin();
     let result = format(&opts.url, &stdin.unwrap_or_default());
     match result {
-        Ok(v) => print!("{}", v),
+        Ok(v) => {
+            let stdout = io::stdout();
+            let mut writer = io::BufWriter::new(stdout.lock());
+            writer.write_all(v.as_bytes()).unwrap();
+        }
         Err(e) => {
             eprint!("Error formatting with blackd-client: {}", e);
             std::process::exit(1);


### PR DESCRIPTION
We can use a `BufWriter` instead of `print!` macro to skip the string formatting
