### PR TITLE
refactor: replace clap with pico-args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,19 +257,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bitflags"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
 name = "blackd-client"
 version = "0.0.5"
 dependencies = [
- "clap",
  "custom_error",
  "httpmock",
  "minreq",
+ "pico-args",
  "pretty_assertions",
 ]
 
@@ -333,37 +327,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "3.0.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
- "strsim",
- "termcolor",
- "textwrap",
- "unicase",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -629,15 +592,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "heck"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1000,15 +954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7afeb98c5a10e0bffcc7fc16e105b04d06729fac5fd6384aebf7ff5cb5a67d"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -1121,30 +1066,6 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1354,12 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,24 +1294,6 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1507,15 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,18 +1420,6 @@ checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -1577,12 +1453,6 @@ name = "vcpkg"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "waker-fn"
@@ -1706,15 +1576,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/disrupted/blackd-client"
 description = "Blazing fast Python code formatting using Black"
 
 [dependencies]
-clap = "3.0.0-beta.5"
 custom_error = "1.9.2"
 minreq = "2.3.1"
+pico-args = { version = "0.4.2", default_features = false }
 
 [dev-dependencies]
 httpmock = "0.5.8"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# blackd-client (WIP)
+# blackd-client
 
 > Tiny HTTP client for the Black (`blackd`) Python code formatter
 
 [Black](https://github.com/psf/black) is a brilliant, opinionated formatter for Python. However it can be quite slow when using an editor integration with format on save, since the process is cold-started every time you call it.
 
-Luckily there's [blackd](https://black.readthedocs.io/en/stable/usage_and_configuration/black_as_a_server.html) which is a small HTTP server that keeps the Black process running in the background so that it can be called directly without the lenghty startup time.
+Luckily there's [blackd](https://black.readthedocs.io/en/stable/usage_and_configuration/black_as_a_server.html), which is a small HTTP server that keeps the Black process running in the background so that it can be called directly without the lenghty startup time.
 
 **blackd-client** is a simple helper that provides a single executable to communicate with Black, mainly for me to learn Rust.
 
@@ -77,8 +77,15 @@ Using `blackd-client`
 
 **Result:** blackd is more than 10x faster! :rocket:
 
-## Neovim integration using EFM language server
+## Neovim integration
 
-[my configuration](https://github.com/disrupted/dotfiles/blob/master/.config/nvim/lua/efm/blackd.lua)
+Editor integration for Neovim can be done using a general purpose language server.
+There are two options to choose from:
 
-_TODO_ describe steps
+1. null-ls (what I use)
+
+[null-ls config](https://github.com/disrupted/dotfiles/blob/master/.config/nvim/lua/conf/null-ls.lua)
+
+2. EFM
+
+[EFM config](https://github.com/disrupted/dotfiles/blob/253dc440ed954a4289a72dad885c71c16d0f90a4/.config/nvim/lua/efm/blackd.lua)

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ Using `blackd-client`
 Editor integration for Neovim can be done using a general purpose language server.
 There are two options to choose from:
 
-1. null-ls (what I use)
+1. [null-ls](https://github.com/disrupted/dotfiles/blob/master/.config/nvim/lua/conf/null-ls.lua) (what I use)
 
-[null-ls config](https://github.com/disrupted/dotfiles/blob/master/.config/nvim/lua/conf/null-ls.lua)
-
-2. EFM
-
-[EFM config](https://github.com/disrupted/dotfiles/blob/253dc440ed954a4289a72dad885c71c16d0f90a4/.config/nvim/lua/efm/blackd.lua)
+2. [EFM](https://github.com/disrupted/dotfiles/blob/253dc440ed954a4289a72dad885c71c16d0f90a4/.config/nvim/lua/efm/blackd.lua)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,7 @@ fn main() {
     let stdin = read_stdin();
     let result = format(&opts.url, &stdin.unwrap_or_default());
     match result {
-        Ok(v) => {
-            write_stdout(v.as_bytes()).unwrap();
-        }
+        Ok(v) => write_stdout(v.as_bytes()).unwrap(),
         Err(e) => {
             eprint!("Error formatting with blackd-client: {}", e);
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ fn parse_args() -> Result<AppArgs, pico_args::Error> {
     // It's up to the caller what to do with the remaining arguments.
     let remaining = pargs.finish();
     if !remaining.is_empty() {
-        eprintln!("Warning: unrecognized arguments: {:?}.", remaining);
+        eprintln!("Error: unrecognized arguments: {:?}", remaining);
+        std::process::exit(1);
     }
 
     Ok(args)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@ fn parse_args() -> Result<AppArgs, pico_args::Error> {
         url: pargs.opt_value_from_str("--url")?,
     };
 
-    // It's up to the caller what to do with the remaining arguments.
     let remaining = pargs.finish();
     if !remaining.is_empty() {
         eprintln!("Error: unrecognized arguments: {:?}", remaining);


### PR DESCRIPTION
`clap` is a nice argument parser, but we don't need all the features it provides, so it ends up just wasting a lot of space. In an effort to reduce the binary size I want to switch to using `pico-args`, which is much more lightweight.
